### PR TITLE
fix(css): display nav, move dnone to print mq

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "c-components",
-  "version": "0.1.0",
+  "name": "@joestrouth1/c-components",
+  "version": "0.1.3",
   "main": "dist/index.js",
   "module": "dist/c-components.esm.js",
   "typings": "dist/index.d.ts",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,3 @@
-const postcss = require('rollup-plugin-postcss')
 const autoprefixer = require('autoprefixer')
 const cssnano = require('cssnano')
 

--- a/src/HeaderLegacy/HeaderLegacy.css
+++ b/src/HeaderLegacy/HeaderLegacy.css
@@ -723,14 +723,13 @@
   @page {
     size: a3;
   }
-}
+  ._header-legacy .container {
+    min-width: 992px !important;
+  }
 
-._header-legacy .container {
-  min-width: 992px !important;
-}
-
-._header-legacy .navbar {
-  display: none;
+  ._header-legacy .navbar {
+    display: none;
+  }
 }
 
 ._header-legacy a.btn {
@@ -1220,6 +1219,1234 @@
   }
 
   ._header-legacy li.nav-item {
+    text-align: right !important;
+    width: 100%;
+    padding-right: 50px;
+  }
+}
+
+/* Not prefixed */
+/*!
+*  Font Awesome 4.6.1 by @davegandy - http://fontawesome.io - @fontawesome
+*  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
+*/
+/* @font-face {
+ font-family: 'FontAwesome';
+ src: url('../fonts/fontawesome-webfont.eot?v=4.6.1');
+ src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.6.1')
+     format('embedded-opentype'),
+   url('../fonts/fontawesome-webfont.woff2?v=4.6.1') format('woff2'),
+   url('../fonts/fontawesome-webfont.woff?v=4.6.1') format('woff'),
+   url('../fonts/fontawesome-webfont.ttf?v=4.6.1') format('truetype'),
+   url('../fonts/fontawesome-webfont.svg?v=4.6.1#fontawesomeregular')
+     format('svg');
+ font-weight: normal;
+ font-style: normal;
+} */
+/*!
+* Bootstrap v4.0.0 (https://getbootstrap.com)
+* Copyright 2011-2018 The Bootstrap Authors
+* Copyright 2011-2018 Twitter, Inc.
+* Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+*/
+/*# sourceMappingURL=bootstrap.min.css.map */
+
+.fa {
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.fa-2x {
+  font-size: 2em;
+}
+
+.pull-right {
+  float: right;
+}
+
+.pull-left {
+  float: left;
+}
+
+.fa.pull-left {
+  margin-right: 0.3em;
+}
+
+.fa.pull-right {
+  margin-left: 0.3em;
+}
+
+@-webkit-keyframes fa-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+@keyframes fa-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+.fa-phone:before {
+  content: '\f095';
+}
+
+.fa-bars:before {
+  content: '\f0c9';
+}
+
+.fa-shield:before {
+  content: '\f132';
+}
+
+*,
+::after,
+::before {
+  box-sizing: border-box;
+}
+
+@-ms-viewport {
+  width: device-width;
+}
+
+figcaption,
+header,
+main,
+nav,
+section {
+  display: block;
+}
+
+[tabindex='-1']:focus {
+  outline: 0 !important;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+ol,
+ul {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+ol ol,
+ol ul,
+ul ol,
+ul ul {
+  margin-bottom: 0;
+}
+
+dfn {
+  font-style: italic;
+}
+
+strong {
+  font-weight: bolder;
+}
+
+small {
+  font-size: 80%;
+}
+
+sup {
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+a {
+  color: #007bff;
+  text-decoration: none;
+  background-color: transparent;
+  -webkit-text-decoration-skip: objects;
+}
+
+a:hover {
+  color: #0056b3;
+  text-decoration: underline;
+}
+
+a:not([href]):not([tabindex]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:not([href]):not([tabindex]):focus,
+a:not([href]):not([tabindex]):hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:not([href]):not([tabindex]):focus {
+  outline: 0;
+}
+
+img {
+  vertical-align: middle;
+  border-style: none;
+}
+
+caption {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  color: #6c757d;
+  text-align: left;
+  caption-side: bottom;
+}
+
+button {
+  border-radius: 0;
+}
+
+button:focus {
+  outline: 1px dotted;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+button,
+input {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+button,
+input {
+  overflow: visible;
+}
+
+button {
+  text-transform: none;
+}
+
+[type='reset'],
+[type='submit'],
+button {
+  -webkit-appearance: button;
+}
+
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner,
+button::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+
+input[type='checkbox'],
+input[type='radio'] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+input[type='date'],
+input[type='datetime-local'],
+input[type='month'],
+input[type='time'] {
+  -webkit-appearance: listbox;
+}
+
+legend {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  padding: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+  line-height: inherit;
+  color: inherit;
+  white-space: normal;
+}
+
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+
+[type='search'] {
+  outline-offset: -2px;
+  -webkit-appearance: none;
+}
+
+[type='search']::-webkit-search-cancel-button,
+[type='search']::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+  font: inherit;
+  -webkit-appearance: button;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+.small,
+small {
+  font-size: 80%;
+  font-weight: 400;
+}
+
+.img-fluid {
+  max-width: 100%;
+  height: auto;
+}
+
+.container {
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+@media (min-width: 576px) {
+  .container {
+    max-width: 540px;
+  }
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 720px;
+  }
+}
+
+@media (min-width: 992px) {
+  .container {
+    max-width: 960px;
+  }
+}
+
+@media (min-width: 1200px) {
+  .container {
+    max-width: 1140px;
+  }
+}
+
+.container-fluid {
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.row {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin-right: -15px;
+  margin-left: -15px;
+}
+
+.col-2,
+.col-4,
+.col-5,
+.col-7,
+.col-lg-5,
+.col-lg-7,
+.col-sm-3,
+.col-sm-9 {
+  position: relative;
+  width: 100%;
+  min-height: 1px;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+.col-2 {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 16.666667%;
+  flex: 0 0 16.666667%;
+  max-width: 16.666667%;
+}
+
+.col-4 {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 33.333333%;
+  flex: 0 0 33.333333%;
+  max-width: 33.333333%;
+}
+
+.col-5 {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 41.666667%;
+  flex: 0 0 41.666667%;
+  max-width: 41.666667%;
+}
+
+.col-7 {
+  -webkit-box-flex: 0;
+  -ms-flex: 0 0 58.333333%;
+  flex: 0 0 58.333333%;
+  max-width: 58.333333%;
+}
+
+@media (min-width: 576px) {
+  .col-sm-3 {
+    -webkit-box-flex: 0;
+    -ms-flex: 0 0 25%;
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+
+  .col-sm-9 {
+    -webkit-box-flex: 0;
+    -ms-flex: 0 0 75%;
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+}
+
+@media (min-width: 992px) {
+  .col-lg-5 {
+    -webkit-box-flex: 0;
+    -ms-flex: 0 0 41.666667%;
+    flex: 0 0 41.666667%;
+    max-width: 41.666667%;
+  }
+
+  .col-lg-7 {
+    -webkit-box-flex: 0;
+    -ms-flex: 0 0 58.333333%;
+    flex: 0 0 58.333333%;
+    max-width: 58.333333%;
+  }
+}
+
+.btn {
+  display: inline-block;
+  font-weight: 400;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border: 1px solid transparent;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: 0.25rem;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.btn:focus,
+.btn:hover {
+  text-decoration: none;
+}
+
+.btn:focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+
+.btn:disabled {
+  opacity: 0.65;
+}
+
+.btn:not(:disabled):not(.disabled) {
+  cursor: pointer;
+}
+
+.btn:not(:disabled):not(.disabled):active {
+  background-image: none;
+}
+
+.collapse {
+  display: none;
+}
+
+.nav {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+
+.navbar {
+  position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+}
+
+.navbar > .container,
+.navbar > .container-fluid {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.navbar-nav {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+
+.navbar-collapse {
+  -ms-flex-preferred-size: 100%;
+  flex-basis: 100%;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.navbar-toggler {
+  padding: 0.25rem 0.75rem;
+  font-size: 1.25rem;
+  line-height: 1;
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+}
+
+.navbar-toggler:focus,
+.navbar-toggler:hover {
+  text-decoration: none;
+}
+
+.navbar-toggler:not(:disabled):not(.disabled) {
+  cursor: pointer;
+}
+
+@media (max-width: 991.98px) {
+  .navbar-expand-lg > .container,
+  .navbar-expand-lg > .container-fluid {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+@media (min-width: 992px) {
+  .navbar-expand-lg {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-flow: row nowrap;
+    flex-flow: row nowrap;
+    -webkit-box-pack: start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
+
+  .navbar-expand-lg .navbar-nav {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+
+  .navbar-expand-lg > .container,
+  .navbar-expand-lg > .container-fluid {
+    -ms-flex-wrap: nowrap;
+    flex-wrap: nowrap;
+  }
+
+  .navbar-expand-lg .navbar-collapse {
+    display: -webkit-box !important;
+    display: -ms-flexbox !important;
+    display: flex !important;
+    -ms-flex-preferred-size: auto;
+    flex-basis: auto;
+  }
+
+  .navbar-expand-lg .navbar-toggler {
+    display: none;
+  }
+}
+
+@-webkit-keyframes progress-bar-stripes {
+  from {
+    background-position: 1rem 0;
+  }
+
+  to {
+    background-position: 0 0;
+  }
+}
+
+@keyframes progress-bar-stripes {
+  from {
+    background-position: 1rem 0;
+  }
+
+  to {
+    background-position: 0 0;
+  }
+}
+
+.d-none {
+  display: none !important;
+}
+
+.d-block {
+  display: block !important;
+}
+
+@media (min-width: 992px) {
+  .d-lg-none {
+    display: none !important;
+  }
+
+  .d-lg-block {
+    display: block !important;
+  }
+}
+
+.justify-content-end {
+  -webkit-box-pack: end !important;
+  -ms-flex-pack: end !important;
+  justify-content: flex-end !important;
+}
+
+@media (min-width: 992px) {
+  .float-lg-right {
+    float: right !important;
+  }
+}
+
+.mr-1 {
+  margin-right: 0.25rem !important;
+}
+
+.ml-1 {
+  margin-left: 0.25rem !important;
+}
+
+.mr-3 {
+  margin-right: 1rem !important;
+}
+
+.ml-3 {
+  margin-left: 1rem !important;
+}
+
+.pt-0 {
+  padding-top: 0 !important;
+}
+
+.pr-0 {
+  padding-right: 0 !important;
+}
+
+.pb-0 {
+  padding-bottom: 0 !important;
+}
+
+.pt-2 {
+  padding-top: 0.5rem !important;
+}
+
+.pr-2 {
+  padding-right: 0.5rem !important;
+}
+
+.pl-2 {
+  padding-left: 0.5rem !important;
+}
+
+.mx-auto {
+  margin-right: auto !important;
+}
+
+.mx-auto {
+  margin-left: auto !important;
+}
+
+.text-left {
+  text-align: left !important;
+}
+
+.text-right {
+  text-align: right !important;
+}
+
+.text-center {
+  text-align: center !important;
+}
+
+@media print {
+  *,
+  ::after,
+  ::before {
+    text-shadow: none !important;
+    box-shadow: none !important;
+  }
+
+  a:not(.btn) {
+    text-decoration: underline;
+  }
+
+  img {
+    page-break-inside: avoid;
+  }
+
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+  @page {
+    size: a3;
+  }
+  .container {
+    min-width: 992px !important;
+  }
+
+  .navbar {
+    display: none;
+  }
+}
+
+a.btn {
+  text-decoration: none;
+}
+
+[type='reset'],
+[type='submit'],
+button {
+  -webkit-appearance: initial;
+}
+
+.btn {
+  white-space: inherit !important;
+}
+
+.btn:focus {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem #7ac143;
+}
+
+.btn-header-apply-sm {
+  background-color: transparent;
+  border: solid 1px #fff;
+  border-radius: 2px;
+  color: #fff !important;
+  text-decoration: none;
+  line-height: 0.6em;
+  padding: 6px 15px;
+  font-size: 12px;
+  max-width: 120px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.btn-header-login-sm {
+  background-color: #7ac143;
+  border: solid 1px #fff;
+  border-radius: 2px;
+  color: #000;
+  text-decoration: none;
+  line-height: 0.65em;
+  padding: 6px 26px;
+  font-size: 12px;
+  max-width: 120px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.midgrey {
+  color: #ccc;
+}
+
+.white {
+  color: #fff !important;
+}
+
+.green {
+  color: #00502f !important;
+}
+
+.light-green {
+  color: #7ac143;
+}
+
+.rel-pos {
+  position: relative;
+}
+
+a {
+  text-decoration: underline;
+  color: #00502f;
+  pointer-events: all;
+}
+
+a.no-underline,
+a.no-underline:visited,
+a.no-underline:active,
+a.no-underline:focus {
+  text-decoration: none !important;
+}
+
+a.no-underline:hover {
+  text-decoration: underline;
+}
+
+a:hover,
+a:visited,
+a:active,
+a:focus {
+  text-decoration: none;
+  color: #00502f;
+}
+
+.rel-pos {
+  position: relative;
+}
+
+.pt-0 {
+  padding-top: 0 !important;
+}
+
+.pr-0 {
+  padding-right: 0 !important;
+}
+
+.pb-0 {
+  padding-bottom: 0 !important;
+}
+
+.mtxs {
+  margin-top: 3px !important;
+}
+
+.mbxs {
+  margin-bottom: 3px !important;
+}
+
+.mr-3 {
+  margin-right: 20px !important;
+}
+
+.pt-2 {
+  padding-top: 10px !important;
+}
+
+.sm-text {
+  font-size: 12px;
+}
+
+.bold {
+  font-weight: 700 !important;
+}
+
+.d-block {
+  display: block;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  z-index: 2000;
+  width: 100%;
+  background-color: #fff;
+  display: block;
+  z-index: 2400;
+}
+
+.log-in-row {
+  background: #00502f;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  height: 40px;
+}
+
+.btn-header-login {
+  background-color: #7ac143;
+  border: solid 1px #fff;
+  border-radius: 2px;
+  color: #000;
+  text-decoration: none;
+  line-height: 0.65em;
+  padding: 8px 28px;
+  font-size: 14px;
+}
+
+.btn-header-login-img {
+  position: absolute;
+  left: 3px;
+  top: 4px;
+}
+
+.btn-header-login:hover,
+.btn-header-login:active,
+.btn-header-login:focus {
+  background-color: #00502f;
+  text-decoration: none;
+  color: #fff;
+}
+
+a.header-link {
+  font-size: 15px;
+  text-decoration: none;
+  padding-right: 0;
+}
+
+a.header-link:hover {
+  text-decoration: underline !important;
+}
+
+.main-nav {
+  width: 100% !important;
+  min-width: 100% !important;
+  box-shadow: 0 0 3px #939393;
+  border-top: solid 1px #dfdfdf;
+}
+
+.navbar-expand-lg {
+  justify-content: flex-end;
+}
+
+li.nav-item {
+  padding-top: 7px;
+  padding-left: 20px;
+  margin: 0 !important;
+}
+
+.security-link {
+  font-size: 12px;
+  line-height: 13px;
+  float: left;
+}
+
+.security-li i {
+  float: left;
+}
+
+.navbar-nav > li > a {
+  padding-bottom: 12px;
+  padding-top: 12px;
+}
+
+.navbar {
+  border: medium none;
+  border-radius: 0;
+  margin-bottom: 0;
+  min-height: 52px;
+}
+
+.header-apply-btn {
+  background-color: #e31b23;
+  border-radius: 2px;
+  padding-top: 3px !important;
+  padding-bottom: 3px !important;
+  color: #fff !important;
+  margin-top: -2px;
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.header-apply-btn:hover,
+.header-apply-btn:focus {
+  background-color: #9f1318;
+}
+
+.logo {
+  position: absolute;
+  left: 20px;
+  top: 35px;
+  z-index: 3000;
+  width: 158px;
+}
+
+.instant-funding-bar {
+  padding-top: 12px;
+  padding-bottom: 10px;
+  background-color: #00502f;
+  margin-top: 92px;
+}
+
+.instant-funding-bar .instant-funding-logo {
+  max-width: 160px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.instant-funding-bar .small {
+  font-size: 12px;
+}
+
+.instant-funding-bar .title {
+  font-size: 16px;
+  color: #00502f;
+}
+
+@media screen and (max-width: 991px) {
+  .logo {
+    left: 5px;
+    top: 36px;
+    width: 110px;
+  }
+
+  .instant-funding-bar .instant-funding-logo {
+    width: 121px;
+    margin: 7px auto 5px auto;
+    padding-top: 0;
+  }
+
+  .instant-funding-bar {
+    position: relative;
+    margin-top: 0;
+    padding-bottom: 2px;
+    padding-top: 4px;
+    margin-top: 85px;
+  }
+
+  .instant-funding-bar .title {
+    font-size: 13px;
+    padding-top: 0;
+    line-height: 17px;
+  }
+
+  .log-in-row {
+    height: 32px;
+  }
+
+  .header-icons div {
+    padding: 4px 0;
+    border-left: solid 1px #007545;
+    border-right: solid 1px #00180e;
+  }
+
+  .header-icons div:first-child {
+    border-left: none;
+  }
+
+  .header-icons div:last-child {
+    border-right: none;
+  }
+
+  .navbar-nav {
+    flex-direction: row-reverse;
+    margin-right: -40px;
+  }
+
+  .log-in-row {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+
+  li.nav-item {
+    padding-top: 18px;
+  }
+}
+
+input::-webkit-input-placeholder {
+  opacity: 0.85 !important;
+}
+
+input:-moz-placeholder {
+  opacity: 0.85 !important;
+}
+
+input::-moz-placeholder {
+  opacity: 0.85 !important;
+}
+
+input:-ms-input-placeholder {
+  opacity: 0.85 !important;
+}
+
+input:focus::-webkit-input-placeholder {
+  opacity: 0.7 !important;
+}
+
+input:focus:-moz-placeholder {
+  opacity: 0.7 !important;
+}
+
+input:focus::-moz-placeholder {
+  opacity: 0.7 !important;
+}
+
+input:focus:-ms-input-placeholder {
+  opacity: 0.7 !important;
+}
+
+.mr-1 {
+  margin-right: 5px !important;
+}
+
+.mr-3 {
+  margin-right: 20px !important;
+}
+
+.ml-1 {
+  margin-left: 5px !important;
+}
+
+.ml-3 {
+  margin-left: 20px !important;
+}
+
+.pt-2 {
+  padding-top: 10px !important;
+}
+
+.pr-2 {
+  padding-right: 10px !important;
+}
+
+.pl-2 {
+  padding-left: 10px !important;
+}
+
+.pt-xs {
+  padding-top: 3px !important;
+}
+
+.pt-0 {
+  padding-top: 0 !important;
+}
+
+.pr-0 {
+  padding-right: 0 !important;
+}
+
+.pb-0 {
+  padding-bottom: 0 !important;
+}
+
+.pt-0 {
+  padding-top: 0 !important;
+}
+
+.pr-0 {
+  padding-right: 0 !important;
+}
+
+.pb-0 {
+  padding-bottom: 0 !important;
+}
+
+a:focus {
+  outline: 2px solid #7ac143 !important;
+}
+
+@media screen and (max-width: 991px) {
+  .log-in-row {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+  }
+
+  .security-link {
+    float: right !important;
+  }
+
+  .security-li i {
+    float: right !important;
+  }
+
+  .collapse.nav {
+    position: absolute;
+    top: 40px;
+    right: 20px;
+  }
+
+  li.nav-item {
+    text-align: right !important;
+    width: 100%;
+    padding-right: 50px;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .header-link {
+    padding-right: 12px;
+  }
+
+  .header-apply-btn {
+    background-color: #e31b23;
+    border-radius: 2px;
+    padding-top: 4px !important;
+    padding-bottom: 4px !important;
+    color: #fff !important;
+    margin-top: 8px;
+    font-size: 14px;
+    font-weight: 700;
+    text-decoration: none;
+    width: 160px;
+    float: right;
+  }
+
+  .security-link {
+    float: right !important;
+  }
+
+  .security-li i {
+    float: right !important;
+  }
+
+  .collapse.nav {
+    position: absolute;
+    top: 40px;
+    right: 20px;
+  }
+
+  li.nav-item {
     text-align: right !important;
     width: 100%;
     padding-right: 50px;

--- a/src/HeaderLegacy/HeaderLegacy.tsx
+++ b/src/HeaderLegacy/HeaderLegacy.tsx
@@ -1,13 +1,13 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import './HeaderLegacy.css'
+import { css } from '@emotion/core'
 
 /**
  * The old HeaderLegacy component
  */
 const HeaderLegacy = () => (
   <div
-    className="_header-legacy"
+    css={css(styles)}
     sx={{
       fontFamily: 'sans',
     }}
@@ -263,3 +263,1232 @@ const HeaderLegacy = () => (
 )
 
 export default HeaderLegacy
+
+const styles = `/*!
+*  Font Awesome 4.6.1 by @davegandy - http://fontawesome.io - @fontawesome
+*  License - http://fontawesome.io/license (Font: SIL OFL 1.1, CSS: MIT License)
+*/
+/* @font-face {
+ font-family: 'FontAwesome';
+ src: url('../fonts/fontawesome-webfont.eot?v=4.6.1');
+ src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.6.1')
+     format('embedded-opentype'),
+   url('../fonts/fontawesome-webfont.woff2?v=4.6.1') format('woff2'),
+   url('../fonts/fontawesome-webfont.woff?v=4.6.1') format('woff'),
+   url('../fonts/fontawesome-webfont.ttf?v=4.6.1') format('truetype'),
+   url('../fonts/fontawesome-webfont.svg?v=4.6.1#fontawesomeregular')
+     format('svg');
+ font-weight: normal;
+ font-style: normal;
+} */
+/*!
+* Bootstrap v4.0.0 (https://getbootstrap.com)
+* Copyright 2011-2018 The Bootstrap Authors
+* Copyright 2011-2018 Twitter, Inc.
+* Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+*/
+/*# sourceMappingURL=bootstrap.min.css.map */
+
+.fa {
+ display: inline-block;
+ font: normal normal normal 14px/1 FontAwesome;
+ font-size: inherit;
+ text-rendering: auto;
+ -webkit-font-smoothing: antialiased;
+ -moz-osx-font-smoothing: grayscale;
+}
+
+.fa-2x {
+ font-size: 2em;
+}
+
+.pull-right {
+ float: right;
+}
+
+.pull-left {
+ float: left;
+}
+
+.fa.pull-left {
+ margin-right: 0.3em;
+}
+
+.fa.pull-right {
+ margin-left: 0.3em;
+}
+
+@-webkit-keyframes fa-spin {
+ 0% {
+   -webkit-transform: rotate(0deg);
+   transform: rotate(0deg);
+ }
+
+ 100% {
+   -webkit-transform: rotate(359deg);
+   transform: rotate(359deg);
+ }
+}
+
+@keyframes fa-spin {
+ 0% {
+   -webkit-transform: rotate(0deg);
+   transform: rotate(0deg);
+ }
+
+ 100% {
+   -webkit-transform: rotate(359deg);
+   transform: rotate(359deg);
+ }
+}
+
+.fa-phone:before {
+ content: '\f095';
+}
+
+.fa-bars:before {
+ content: '\f0c9';
+}
+
+.fa-shield:before {
+ content: '\f132';
+}
+
+*,
+::after,
+::before {
+ box-sizing: border-box;
+}
+
+@-ms-viewport {
+ width: device-width;
+}
+
+figcaption,
+header,
+main,
+nav,
+section {
+ display: block;
+}
+
+[tabindex='-1']:focus {
+ outline: 0 !important;
+}
+
+p {
+ margin-top: 0;
+ margin-bottom: 1rem;
+}
+
+ol,
+ul {
+ margin-top: 0;
+ margin-bottom: 1rem;
+}
+
+ol ol,
+ol ul,
+ul ol,
+ul ul {
+ margin-bottom: 0;
+}
+
+dfn {
+ font-style: italic;
+}
+
+strong {
+ font-weight: bolder;
+}
+
+small {
+ font-size: 80%;
+}
+
+sup {
+ position: relative;
+ font-size: 75%;
+ line-height: 0;
+ vertical-align: baseline;
+}
+
+sup {
+ top: -0.5em;
+}
+
+a {
+ color: #007bff;
+ text-decoration: none;
+ background-color: transparent;
+ -webkit-text-decoration-skip: objects;
+}
+
+a:hover {
+ color: #0056b3;
+ text-decoration: underline;
+}
+
+a:not([href]):not([tabindex]) {
+ color: inherit;
+ text-decoration: none;
+}
+
+a:not([href]):not([tabindex]):focus,
+a:not([href]):not([tabindex]):hover {
+ color: inherit;
+ text-decoration: none;
+}
+
+a:not([href]):not([tabindex]):focus {
+ outline: 0;
+}
+
+img {
+ vertical-align: middle;
+ border-style: none;
+}
+
+caption {
+ padding-top: 0.75rem;
+ padding-bottom: 0.75rem;
+ color: #6c757d;
+ text-align: left;
+ caption-side: bottom;
+}
+
+button {
+ border-radius: 0;
+}
+
+button:focus {
+ outline: 1px dotted;
+ outline: 5px auto -webkit-focus-ring-color;
+}
+
+button,
+input {
+ margin: 0;
+ font-family: inherit;
+ font-size: inherit;
+ line-height: inherit;
+}
+
+button,
+input {
+ overflow: visible;
+}
+
+button {
+ text-transform: none;
+}
+
+[type='reset'],
+[type='submit'],
+button {
+ -webkit-appearance: button;
+}
+
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner,
+button::-moz-focus-inner {
+ padding: 0;
+ border-style: none;
+}
+
+input[type='checkbox'],
+input[type='radio'] {
+ box-sizing: border-box;
+ padding: 0;
+}
+
+input[type='date'],
+input[type='datetime-local'],
+input[type='month'],
+input[type='time'] {
+ -webkit-appearance: listbox;
+}
+
+legend {
+ display: block;
+ width: 100%;
+ max-width: 100%;
+ padding: 0;
+ margin-bottom: 0.5rem;
+ font-size: 1.5rem;
+ line-height: inherit;
+ color: inherit;
+ white-space: normal;
+}
+
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
+ height: auto;
+}
+
+[type='search'] {
+ outline-offset: -2px;
+ -webkit-appearance: none;
+}
+
+[type='search']::-webkit-search-cancel-button,
+[type='search']::-webkit-search-decoration {
+ -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+ font: inherit;
+ -webkit-appearance: button;
+}
+
+[hidden] {
+ display: none !important;
+}
+
+.small,
+small {
+ font-size: 80%;
+ font-weight: 400;
+}
+
+.img-fluid {
+ max-width: 100%;
+ height: auto;
+}
+
+.container {
+ width: 100%;
+ padding-right: 15px;
+ padding-left: 15px;
+ margin-right: auto;
+ margin-left: auto;
+}
+
+@media (min-width: 576px) {
+ .container {
+   max-width: 540px;
+ }
+}
+
+@media (min-width: 768px) {
+ .container {
+   max-width: 720px;
+ }
+}
+
+@media (min-width: 992px) {
+ .container {
+   max-width: 960px;
+ }
+}
+
+@media (min-width: 1200px) {
+ .container {
+   max-width: 1140px;
+ }
+}
+
+.container-fluid {
+ width: 100%;
+ padding-right: 15px;
+ padding-left: 15px;
+ margin-right: auto;
+ margin-left: auto;
+}
+
+.row {
+ display: -webkit-box;
+ display: -ms-flexbox;
+ display: flex;
+ -ms-flex-wrap: wrap;
+ flex-wrap: wrap;
+ margin-right: -15px;
+ margin-left: -15px;
+}
+
+.col-2,
+.col-4,
+.col-5,
+.col-7,
+.col-lg-5,
+.col-lg-7,
+.col-sm-3,
+.col-sm-9 {
+ position: relative;
+ width: 100%;
+ min-height: 1px;
+ padding-right: 15px;
+ padding-left: 15px;
+}
+
+.col-2 {
+ -webkit-box-flex: 0;
+ -ms-flex: 0 0 16.666667%;
+ flex: 0 0 16.666667%;
+ max-width: 16.666667%;
+}
+
+.col-4 {
+ -webkit-box-flex: 0;
+ -ms-flex: 0 0 33.333333%;
+ flex: 0 0 33.333333%;
+ max-width: 33.333333%;
+}
+
+.col-5 {
+ -webkit-box-flex: 0;
+ -ms-flex: 0 0 41.666667%;
+ flex: 0 0 41.666667%;
+ max-width: 41.666667%;
+}
+
+.col-7 {
+ -webkit-box-flex: 0;
+ -ms-flex: 0 0 58.333333%;
+ flex: 0 0 58.333333%;
+ max-width: 58.333333%;
+}
+
+@media (min-width: 576px) {
+ .col-sm-3 {
+   -webkit-box-flex: 0;
+   -ms-flex: 0 0 25%;
+   flex: 0 0 25%;
+   max-width: 25%;
+ }
+
+ .col-sm-9 {
+   -webkit-box-flex: 0;
+   -ms-flex: 0 0 75%;
+   flex: 0 0 75%;
+   max-width: 75%;
+ }
+}
+
+@media (min-width: 992px) {
+ .col-lg-5 {
+   -webkit-box-flex: 0;
+   -ms-flex: 0 0 41.666667%;
+   flex: 0 0 41.666667%;
+   max-width: 41.666667%;
+ }
+
+ .col-lg-7 {
+   -webkit-box-flex: 0;
+   -ms-flex: 0 0 58.333333%;
+   flex: 0 0 58.333333%;
+   max-width: 58.333333%;
+ }
+}
+
+.btn {
+ display: inline-block;
+ font-weight: 400;
+ text-align: center;
+ white-space: nowrap;
+ vertical-align: middle;
+ -webkit-user-select: none;
+ -moz-user-select: none;
+ -ms-user-select: none;
+ user-select: none;
+ border: 1px solid transparent;
+ padding: 0.375rem 0.75rem;
+ font-size: 1rem;
+ line-height: 1.5;
+ border-radius: 0.25rem;
+ transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out,
+   border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.btn:focus,
+.btn:hover {
+ text-decoration: none;
+}
+
+.btn:focus {
+ outline: 0;
+ box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+
+.btn:disabled {
+ opacity: 0.65;
+}
+
+.btn:not(:disabled):not(.disabled) {
+ cursor: pointer;
+}
+
+.btn:not(:disabled):not(.disabled):active {
+ background-image: none;
+}
+
+.collapse {
+ display: none;
+}
+
+.nav {
+ display: -webkit-box;
+ display: -ms-flexbox;
+ display: flex;
+ -ms-flex-wrap: wrap;
+ flex-wrap: wrap;
+ padding-left: 0;
+ margin-bottom: 0;
+ list-style: none;
+}
+
+.navbar {
+ position: relative;
+ display: -webkit-box;
+ display: -ms-flexbox;
+ display: flex;
+ -ms-flex-wrap: wrap;
+ flex-wrap: wrap;
+ -webkit-box-align: center;
+ -ms-flex-align: center;
+ align-items: center;
+ -webkit-box-pack: justify;
+ -ms-flex-pack: justify;
+ justify-content: space-between;
+ padding: 0.5rem 1rem;
+}
+
+.navbar > .container,
+.navbar > .container-fluid {
+ display: -webkit-box;
+ display: -ms-flexbox;
+ display: flex;
+ -ms-flex-wrap: wrap;
+ flex-wrap: wrap;
+ -webkit-box-align: center;
+ -ms-flex-align: center;
+ align-items: center;
+ -webkit-box-pack: justify;
+ -ms-flex-pack: justify;
+ justify-content: space-between;
+}
+
+.navbar-nav {
+ display: -webkit-box;
+ display: -ms-flexbox;
+ display: flex;
+ -webkit-box-orient: vertical;
+ -webkit-box-direction: normal;
+ -ms-flex-direction: column;
+ flex-direction: column;
+ padding-left: 0;
+ margin-bottom: 0;
+ list-style: none;
+}
+
+.navbar-collapse {
+ -ms-flex-preferred-size: 100%;
+ flex-basis: 100%;
+ -webkit-box-flex: 1;
+ -ms-flex-positive: 1;
+ flex-grow: 1;
+ -webkit-box-align: center;
+ -ms-flex-align: center;
+ align-items: center;
+}
+
+.navbar-toggler {
+ padding: 0.25rem 0.75rem;
+ font-size: 1.25rem;
+ line-height: 1;
+ background-color: transparent;
+ border: 1px solid transparent;
+ border-radius: 0.25rem;
+}
+
+.navbar-toggler:focus,
+.navbar-toggler:hover {
+ text-decoration: none;
+}
+
+.navbar-toggler:not(:disabled):not(.disabled) {
+ cursor: pointer;
+}
+
+@media (max-width: 991.98px) {
+ .navbar-expand-lg > .container,
+ .navbar-expand-lg > .container-fluid {
+   padding-right: 0;
+   padding-left: 0;
+ }
+}
+
+@media (min-width: 992px) {
+ .navbar-expand-lg {
+   -webkit-box-orient: horizontal;
+   -webkit-box-direction: normal;
+   -ms-flex-flow: row nowrap;
+   flex-flow: row nowrap;
+   -webkit-box-pack: start;
+   -ms-flex-pack: start;
+   justify-content: flex-start;
+ }
+
+ .navbar-expand-lg .navbar-nav {
+   -webkit-box-orient: horizontal;
+   -webkit-box-direction: normal;
+   -ms-flex-direction: row;
+   flex-direction: row;
+ }
+
+ .navbar-expand-lg > .container,
+ .navbar-expand-lg > .container-fluid {
+   -ms-flex-wrap: nowrap;
+   flex-wrap: nowrap;
+ }
+
+ .navbar-expand-lg .navbar-collapse {
+   display: -webkit-box !important;
+   display: -ms-flexbox !important;
+   display: flex !important;
+   -ms-flex-preferred-size: auto;
+   flex-basis: auto;
+ }
+
+ .navbar-expand-lg .navbar-toggler {
+   display: none;
+ }
+}
+
+@-webkit-keyframes progress-bar-stripes {
+ from {
+   background-position: 1rem 0;
+ }
+
+ to {
+   background-position: 0 0;
+ }
+}
+
+@keyframes progress-bar-stripes {
+ from {
+   background-position: 1rem 0;
+ }
+
+ to {
+   background-position: 0 0;
+ }
+}
+
+.d-none {
+ display: none !important;
+}
+
+.d-block {
+ display: block !important;
+}
+
+@media (min-width: 992px) {
+ .d-lg-none {
+   display: none !important;
+ }
+
+ .d-lg-block {
+   display: block !important;
+ }
+}
+
+.justify-content-end {
+ -webkit-box-pack: end !important;
+ -ms-flex-pack: end !important;
+ justify-content: flex-end !important;
+}
+
+@media (min-width: 992px) {
+ .float-lg-right {
+   float: right !important;
+ }
+}
+
+.mr-1 {
+ margin-right: 0.25rem !important;
+}
+
+.ml-1 {
+ margin-left: 0.25rem !important;
+}
+
+.mr-3 {
+ margin-right: 1rem !important;
+}
+
+.ml-3 {
+ margin-left: 1rem !important;
+}
+
+.pt-0 {
+ padding-top: 0 !important;
+}
+
+.pr-0 {
+ padding-right: 0 !important;
+}
+
+.pb-0 {
+ padding-bottom: 0 !important;
+}
+
+.pt-2 {
+ padding-top: 0.5rem !important;
+}
+
+.pr-2 {
+ padding-right: 0.5rem !important;
+}
+
+.pl-2 {
+ padding-left: 0.5rem !important;
+}
+
+.mx-auto {
+ margin-right: auto !important;
+}
+
+.mx-auto {
+ margin-left: auto !important;
+}
+
+.text-left {
+ text-align: left !important;
+}
+
+.text-right {
+ text-align: right !important;
+}
+
+.text-center {
+ text-align: center !important;
+}
+
+@media print {
+ *,
+ ::after,
+ ::before {
+   text-shadow: none !important;
+   box-shadow: none !important;
+ }
+
+ a:not(.btn) {
+   text-decoration: underline;
+ }
+
+ img {
+   page-break-inside: avoid;
+ }
+
+ p {
+   orphans: 3;
+   widows: 3;
+ }
+ @page {
+   size: a3;
+ }
+ .container {
+  min-width: 992px !important;
+ }
+ 
+ .navbar {
+  display: none;
+ }
+}
+
+
+a.btn {
+ text-decoration: none;
+}
+
+[type='reset'],
+[type='submit'],
+button {
+ -webkit-appearance: initial;
+}
+
+.btn {
+ white-space: inherit !important;
+}
+
+.btn:focus {
+ outline: 0;
+ box-shadow: 0 0 0 0.2rem #7ac143;
+}
+
+.btn-header-apply-sm {
+ background-color: transparent;
+ border: solid 1px #fff;
+ border-radius: 2px;
+ color: #fff !important;
+ text-decoration: none;
+ line-height: 0.6em;
+ padding: 6px 15px;
+ font-size: 12px;
+ max-width: 120px;
+ margin-left: auto;
+ margin-right: auto;
+}
+
+.btn-header-login-sm {
+ background-color: #7ac143;
+ border: solid 1px #fff;
+ border-radius: 2px;
+ color: #000;
+ text-decoration: none;
+ line-height: 0.65em;
+ padding: 6px 26px;
+ font-size: 12px;
+ max-width: 120px;
+ margin-left: auto;
+ margin-right: auto;
+}
+
+.midgrey {
+ color: #ccc;
+}
+
+.white {
+ color: #fff !important;
+}
+
+.green {
+ color: #00502f !important;
+}
+
+.light-green {
+ color: #7ac143;
+}
+
+.rel-pos {
+ position: relative;
+}
+
+a {
+ text-decoration: underline;
+ color: #00502f;
+ pointer-events: all;
+}
+
+a.no-underline,
+a.no-underline:visited,
+a.no-underline:active,
+a.no-underline:focus {
+ text-decoration: none !important;
+}
+
+a.no-underline:hover {
+ text-decoration: underline;
+}
+
+a:hover,
+a:visited,
+a:active,
+a:focus {
+ text-decoration: none;
+ color: #00502f;
+}
+
+.rel-pos {
+ position: relative;
+}
+
+.pt-0 {
+ padding-top: 0 !important;
+}
+
+.pr-0 {
+ padding-right: 0 !important;
+}
+
+.pb-0 {
+ padding-bottom: 0 !important;
+}
+
+.mtxs {
+ margin-top: 3px !important;
+}
+
+.mbxs {
+ margin-bottom: 3px !important;
+}
+
+.mr-3 {
+ margin-right: 20px !important;
+}
+
+.pt-2 {
+ padding-top: 10px !important;
+}
+
+.sm-text {
+ font-size: 12px;
+}
+
+.bold {
+ font-weight: 700 !important;
+}
+
+.d-block {
+ display: block;
+}
+
+header {
+ position: fixed;
+ top: 0;
+ z-index: 2000;
+ width: 100%;
+ background-color: #fff;
+ display: block;
+ z-index: 2400;
+}
+
+.log-in-row {
+ background: #00502f;
+ padding-top: 8px;
+ padding-bottom: 8px;
+ height: 40px;
+}
+
+.btn-header-login {
+ background-color: #7ac143;
+ border: solid 1px #fff;
+ border-radius: 2px;
+ color: #000;
+ text-decoration: none;
+ line-height: 0.65em;
+ padding: 8px 28px;
+ font-size: 14px;
+}
+
+.btn-header-login-img {
+ position: absolute;
+ left: 3px;
+ top: 4px;
+}
+
+.btn-header-login:hover,
+.btn-header-login:active,
+.btn-header-login:focus {
+ background-color: #00502f;
+ text-decoration: none;
+ color: #fff;
+}
+
+a.header-link {
+ font-size: 15px;
+ text-decoration: none;
+ padding-right: 0;
+}
+
+a.header-link:hover {
+ text-decoration: underline !important;
+}
+
+.main-nav {
+ width: 100% !important;
+ min-width: 100% !important;
+ box-shadow: 0 0 3px #939393;
+ border-top: solid 1px #dfdfdf;
+}
+
+.navbar-expand-lg {
+ justify-content: flex-end;
+}
+
+li.nav-item {
+ padding-top: 7px;
+ padding-left: 20px;
+ margin: 0 !important;
+}
+
+.security-link {
+ font-size: 12px;
+ line-height: 13px;
+ float: left;
+}
+
+.security-li i {
+ float: left;
+}
+
+.navbar-nav > li > a {
+ padding-bottom: 12px;
+ padding-top: 12px;
+}
+
+.navbar {
+ border: medium none;
+ border-radius: 0;
+ margin-bottom: 0;
+ min-height: 52px;
+}
+
+.header-apply-btn {
+ background-color: #e31b23;
+ border-radius: 2px;
+ padding-top: 3px !important;
+ padding-bottom: 3px !important;
+ color: #fff !important;
+ margin-top: -2px;
+ font-size: 12px;
+ font-weight: 700;
+ text-decoration: none;
+}
+
+.header-apply-btn:hover,
+.header-apply-btn:focus {
+ background-color: #9f1318;
+}
+
+.logo {
+ position: absolute;
+ left: 20px;
+ top: 35px;
+ z-index: 3000;
+ width: 158px;
+}
+
+.instant-funding-bar {
+ padding-top: 12px;
+ padding-bottom: 10px;
+ background-color: #00502f;
+ margin-top: 92px;
+}
+
+.instant-funding-bar .instant-funding-logo {
+ max-width: 160px;
+ margin-left: auto;
+ margin-right: auto;
+}
+
+.instant-funding-bar .small {
+ font-size: 12px;
+}
+
+.instant-funding-bar .title {
+ font-size: 16px;
+ color: #00502f;
+}
+
+@media screen and (max-width: 991px) {
+ .logo {
+   left: 5px;
+   top: 36px;
+   width: 110px;
+ }
+
+ .instant-funding-bar .instant-funding-logo {
+   width: 121px;
+   margin: 7px auto 5px auto;
+   padding-top: 0;
+ }
+
+ .instant-funding-bar {
+   position: relative;
+   margin-top: 0;
+   padding-bottom: 2px;
+   padding-top: 4px;
+   margin-top: 85px;
+ }
+
+ .instant-funding-bar .title {
+   font-size: 13px;
+   padding-top: 0;
+   line-height: 17px;
+ }
+
+ .log-in-row {
+   height: 32px;
+ }
+
+ .header-icons div {
+   padding: 4px 0;
+   border-left: solid 1px #007545;
+   border-right: solid 1px #00180e;
+ }
+
+ .header-icons div:first-child {
+   border-left: none;
+ }
+
+ .header-icons div:last-child {
+   border-right: none;
+ }
+
+ .navbar-nav {
+   flex-direction: row-reverse;
+   margin-right: -40px;
+ }
+
+ .log-in-row {
+   padding-top: 0 !important;
+   padding-bottom: 0 !important;
+ }
+
+ li.nav-item {
+   padding-top: 18px;
+ }
+}
+
+input::-webkit-input-placeholder {
+ opacity: 0.85 !important;
+}
+
+input:-moz-placeholder {
+ opacity: 0.85 !important;
+}
+
+input::-moz-placeholder {
+ opacity: 0.85 !important;
+}
+
+input:-ms-input-placeholder {
+ opacity: 0.85 !important;
+}
+
+input:focus::-webkit-input-placeholder {
+ opacity: 0.7 !important;
+}
+
+input:focus:-moz-placeholder {
+ opacity: 0.7 !important;
+}
+
+input:focus::-moz-placeholder {
+ opacity: 0.7 !important;
+}
+
+input:focus:-ms-input-placeholder {
+ opacity: 0.7 !important;
+}
+
+.mr-1 {
+ margin-right: 5px !important;
+}
+
+.mr-3 {
+ margin-right: 20px !important;
+}
+
+.ml-1 {
+ margin-left: 5px !important;
+}
+
+.ml-3 {
+ margin-left: 20px !important;
+}
+
+.pt-2 {
+ padding-top: 10px !important;
+}
+
+.pr-2 {
+ padding-right: 10px !important;
+}
+
+.pl-2 {
+ padding-left: 10px !important;
+}
+
+.pt-xs {
+ padding-top: 3px !important;
+}
+
+.pt-0 {
+ padding-top: 0 !important;
+}
+
+.pr-0 {
+ padding-right: 0 !important;
+}
+
+.pb-0 {
+ padding-bottom: 0 !important;
+}
+
+.pt-0 {
+ padding-top: 0 !important;
+}
+
+.pr-0 {
+ padding-right: 0 !important;
+}
+
+.pb-0 {
+ padding-bottom: 0 !important;
+}
+
+a:focus {
+ outline: 2px solid #7ac143 !important;
+}
+
+@media screen and (max-width: 991px) {
+ .log-in-row {
+   padding-top: 0 !important;
+   padding-bottom: 0 !important;
+ }
+
+ .security-link {
+   float: right !important;
+ }
+
+ .security-li i {
+   float: right !important;
+ }
+
+ .collapse.nav {
+   position: absolute;
+   top: 40px;
+   right: 20px;
+ }
+
+ li.nav-item {
+   text-align: right !important;
+   width: 100%;
+   padding-right: 50px;
+ }
+}
+
+@media screen and (max-width: 767px) {
+ .header-link {
+   padding-right: 12px;
+ }
+
+ .header-apply-btn {
+   background-color: #e31b23;
+   border-radius: 2px;
+   padding-top: 4px !important;
+   padding-bottom: 4px !important;
+   color: #fff !important;
+   margin-top: 8px;
+   font-size: 14px;
+   font-weight: 700;
+   text-decoration: none;
+   width: 160px;
+   float: right;
+ }
+
+ .security-link {
+   float: right !important;
+ }
+
+ .security-li i {
+   float: right !important;
+ }
+
+ .collapse.nav {
+   position: absolute;
+   top: 40px;
+   right: 20px;
+ }
+
+ li.nav-item {
+   text-align: right !important;
+   width: 100%;
+   padding-right: 50px;
+ }
+}
+`


### PR DESCRIPTION
Navbar was mistakenly set to `display: none`. That rule and a couple others should have been inside a print media query. That's been fixed, and the styles have been unprefixed & set via Emotion's CSS prop, rather than manually namespaced. This makes it easier to distribute styles with the component rather than trying to publish the CSS file or have them injected.